### PR TITLE
Pass PEP8 on all but relative imports.

### DIFF
--- a/nclxd/cmd/converter.py
+++ b/nclxd/cmd/converter.py
@@ -1,5 +1,19 @@
 #!/usr/bin/python
 
+# Copyright (c) 2015 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 import json
 import optparse
 import os
@@ -7,43 +21,45 @@ import subprocess
 import tempfile
 import time
 
+
 def parse_argv():
-	optparser = optparse.OptionParser()
-	optparser.add_option('-i', '--image',
-						 help='Path to image', dest='image', metavar='PATH')
-	(opts, args) = optparser.parse_args()
+    optparser = optparse.OptionParser()
+    optparser.add_option('-i', '--image',
+                         help='Path to image', dest='image', metavar='PATH')
+    (opts, args) = optparser.parse_args()
 
-	if not os.path.exists(opts.image):
-		optparser.error('Unable to open file')
+    if not os.path.exists(opts.image):
+        optparser.error('Unable to open file')
 
-	return (opts, args)
+    return (opts, args)
+
 
 def create_tarball():
-	workdir = tempfile.mkdtemp()
-	rootfs_dir = os.path.join(workdir, 'rootfs')
-	os.mkdir(rootfs_dir)
-	image = opts.image
-	r = subprocess.call(['tar', '--anchored', '--numeric-owner', 
-						 '--exclude=dev/*', '-zxf', image,
-                         '-C', rootfs_dir])
+    workdir = tempfile.mkdtemp()
+    rootfs_dir = os.path.join(workdir, 'rootfs')
+    os.mkdir(rootfs_dir)
+    image = opts.image
+    subprocess.call(['tar', '--anchored', '--numeric-owner',
+                     '--exclude=dev/*', '-zxf', image,
+                     '-C', rootfs_dir])
 
-	epoch = time.time()
-	metadata = {
-		'architecutre': 'x86_64',
-		'creation_date': int(epoch)
-	}
-	metadata_yaml = json.dumps(metadata, sort_keys=True,
-							   indent=4, separators=(',', ': '),
-							   ensure_ascii=False).encode('utf-8') + b"\n"
-	metadata_file = os.path.join(workdir, 'metadata.yaml')
-	with open(metadata_file, 'w') as fp:
-		fp.write(metadata_yaml)
-	source_tarball = image.split('.')
-	dest_tarball = "%s-lxd.tar.gz"  % source_tarball[0]
-	r = subprocess.call(['tar', '-C', workdir, '-zcf',
-						 dest_tarball, 'metadata.yaml', 'rootfs'])
+    epoch = time.time()
+    metadata = {
+        'architecutre': 'x86_64',
+        'creation_date': int(epoch)
+    }
+    metadata_yaml = json.dumps(metadata, sort_keys=True,
+                               indent=4, separators=(',', ': '),
+                               ensure_ascii=False).encode('utf-8') + b"\n"
+    metadata_file = os.path.join(workdir, 'metadata.yaml')
+    with open(metadata_file, 'w') as fp:
+        fp.write(metadata_yaml)
+    source_tarball = image.split('.')
+    dest_tarball = "%s-lxd.tar.gz" % source_tarball[0]
+    subprocess.call(['tar', '-C', workdir, '-zcf',
+                     dest_tarball, 'metadata.yaml', 'rootfs'])
 
 if __name__ == '__main__':
-	(opts, args) = parse_argv()
+    (opts, args) = parse_argv()
 
-	create_tarball()
+    create_tarball()

--- a/nclxd/nova/virt/lxd/driver.py
+++ b/nclxd/nova/virt/lxd/driver.py
@@ -21,23 +21,19 @@ Nova LXD Driver
 
 """
 
-import socket
 import multiprocessing
-
-from oslo.utils import units
-
-from oslo.config import cfg
-from oslo_log import log as logging
-from oslo.serialization import jsonutils
+import socket
 
 import client
-
-from nova.i18n import _
-from nova.virt import driver
-from nova.virt import hardware
-
 import container
 import host_utils
+from nova.virt import driver
+from nova.virt import hardware
+from oslo.config import cfg
+from oslo.serialization import jsonutils
+from oslo.utils import units
+from oslo_log import log as logging
+
 
 lxd_opts = [
     cfg.StrOpt('lxd_socket',
@@ -84,17 +80,19 @@ class LXDDriver(driver.ComputeDriver):
               admin_password, network_info=None, block_device_info=None,
               flavor=None):
         self.container.container_start(context, instance, image_meta,
-                                       injected_files, admin_password, network_info,
-                                       block_device_info, flavor)
+                                       injected_files, admin_password,
+                                       network_info, block_device_info,
+                                       flavor)
 
     def snapshot(self, context, instance, name, update_task_state):
         raise NotImplemented()
 
     def reboot(self, context, instance, network_info, reboot_type,
                block_device_info=None, bad_volumes_callback=None):
-        self.container.container_restart(
-            context, instance, network_info, reboot_type,
-                                         block_device_info, bad_volumes_callback)
+        self.container.container_restart(context, instance,
+                                         network_info, reboot_type,
+                                         block_device_info,
+                                         bad_volumes_callback)
 
     def rescue(self, context, instance, network_info, image_meta,
                rescue_password):
@@ -145,12 +143,14 @@ class LXDDriver(driver.ComputeDriver):
         return self.container.container_suspend(instance)
 
     def resume(self, context, instance, network_info, block_device_info=None):
-        return self.container.container_resume(context, instance, network_info, block_device_info)
+        return self.container.container_resume(context, instance, network_info,
+                                               block_device_info)
 
     def destroy(self, context, instance, network_info, block_device_info=None,
                 destroy_disks=True, migrate_data=None):
-        return self.container.container_destroy(
-            context, instance, network_info, block_device_info,
+        return self.container.container_destroy(context, instance,
+                                                network_info,
+                                                block_device_info,
                                                 destroy_disks, migrate_data)
 
     def cleanup(self, context, instance, network_info, block_device_info=None,

--- a/nclxd/nova/virt/lxd/images.py
+++ b/nclxd/nova/virt/lxd/images.py
@@ -14,16 +14,14 @@
 
 import os
 
-
-from oslo.config import cfg
-from oslo_log import log as logging
-from oslo_utils import excutils
-
-from nova.i18n import _, _LE
+from nova.i18n import _
+from nova.i18n import _LE
 from nova.openstack.common import fileutils
 from nova import utils
 from nova.virt import images
-from nova import exception
+from oslo.config import cfg
+from oslo_log import log as logging
+from oslo_utils import excutils
 
 CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
@@ -72,8 +70,8 @@ class ContainerImage(object):
                          max_size=max_size)
         except Exception:
             LOG.exception(_LE("Image %(image_id)s doesn't exist anymore on "
-                          "image service, attempting to copy image ",
-                              {'image_id': instance.image_ref}))
+                              "image service, attempting to copy image "),
+                          {'image_id': instance.image_ref})
 
         fileutils.ensure_tree(self.image_dir)
         (user, group) = self.idmap.get_user()
@@ -102,18 +100,19 @@ class ContainerImage(object):
                                               instance.uuid, 'rootfs')
                 if not os.path.exists(self.upper_dir):
                     utils.execute('mkdir', '-p', self.upper_dir,
-                              run_as_root=True)
+                                  run_as_root=True)
 
                 self.work_dir = os.path.join(CONF.lxd.lxd_root_dir,
-                                                instance.uuid, 'workdir')
+                                             instance.uuid, 'workdir')
                 if not os.path.exists(self.work_dir):
                     utils.execute('mkdir', '-p', self.work_dir,
-                              run_as_root=True)
+                                  run_as_root=True)
 
                 utils.execute('mount', '-t', 'overlayfs', 'overlayfs',
                               '-o',
                               'lowerdir=%s,upperdir=%s,workdir=%s'
-                              % (self.image_dir, self.upper_dir, self.work_dir),
+                              % (self.image_dir, self.upper_dir,
+                                 self.work_dir),
                               self.rootfs_dir,
                               run_as_root=True)
         except Exception:

--- a/nclxd/nova/virt/lxd/utils.py
+++ b/nclxd/nova/virt/lxd/utils.py
@@ -12,9 +12,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import grp
 import os
 import pwd
-import grp
+
 
 class LXCIdMap(object):
 
@@ -46,6 +47,7 @@ class LXCIdMap(object):
 
     def get_user(self):
         return (self.ustart, self.gstart)
+
 
 class LXCUserIdMap(LXCIdMap):
 

--- a/nclxd/nova/virt/lxd/vif.py
+++ b/nclxd/nova/virt/lxd/vif.py
@@ -12,20 +12,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import getpass
-
-import os
-
-from oslo.config import cfg
-from oslo_log import log as logging
-from oslo_concurrency import processutils
-
-
-from nova.i18n import _LW, _
 from nova import exception
-from nova import utils
+from nova.i18n import _
 from nova.network import linux_net
 from nova.network import model as network_model
+from nova import utils
+from oslo.config import cfg
+from oslo_concurrency import processutils
+from oslo_log import log as logging
 
 
 CONF = cfg.CONF
@@ -128,19 +122,19 @@ class LXDNetworkBridgeDriver(object):
         if (not network.get_meta('multi_host', False) and
                 network.get_meta('should_create_bridge', False)):
             if network.get_meta('should_create_vlan', False):
-                iface = CONF.vlan_interface or \
-                    network.get_meta('bridge_interface')
+                iface = CONF.vlan_interface or (
+                    network.get_meta('bridge_interface'))
                 LOG.debug('Ensuring vlan %(vlan)s and bridge %(bridge)s',
                           {'vlan': network.get_meta('vlan'),
                            'bridge': vif['network']['bridge']},
                           instance=instance)
                 linux_net.LinuxBridgeInterfaceDriver.ensure_vlan_bridge(
                     network.get_meta('vlan'),
-                     vif['network']['bridge'],
-                     iface)
+                    vif['network']['bridge'],
+                    iface)
             else:
-                iface = CONF.flat_interface or \
-                    network.get_meta('bridge_interface')
+                iface = CONF.flat_interface or (
+                    network.get_meta('bridge_interface'))
                 LOG.debug("Ensuring bridge %s",
                           vif['network']['bridge'], instance=instance)
                 linux_net.LinuxBridgeInterfaceDriver.ensure_bridge(

--- a/nclxd/tests/test_client.py
+++ b/nclxd/tests/test_client.py
@@ -1,10 +1,25 @@
+# Copyright (c) 2015 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 import json
+
 import mock
+from nova import test
 import requests
 
-from nova import test
-
 from nclxd.nova.virt.lxd import client
+
 
 class LXDFakeResponse(object):
     """Fake response to LXD API."""
@@ -20,6 +35,7 @@ class LXDFakeResponse(object):
         if self.status_code > 300:
             raise requests.exception.HTTPError
 
+
 class LXDTestClient(test.TestCase):
     def setUp(self):
         super(LXDTestClient, self).setUp()
@@ -27,14 +43,16 @@ class LXDTestClient(test.TestCase):
         self.client = client.Client('https://127.0.0.1:8443',
                                     'client',
                                     'key')
+
     def test_client_defined(self):
         requests.get = mock.Mock(return_value=True)
         instance = self.client.defined('test')
         self.assertTrue(instance)
 
     def test_client_state(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata": {"state": "RUNNING",
+                                               "state_code": 3}})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.get = mock.Mock(return_value=get_return)
@@ -42,8 +60,9 @@ class LXDTestClient(test.TestCase):
         self.assertIn('RUNNING', instance)
 
     def test_client_running(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata": {"state": "RUNNING",
+                                               "state_code": 3}})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.get = mock.Mock(return_value=get_return)
@@ -51,18 +70,20 @@ class LXDTestClient(test.TestCase):
         self.assertTrue(instance)
 
     def test_client_list(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":["dc5a4fd8-a43e-486f-9e2c-fb07917f2915"]})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata":
+                                 ["dc5a4fd8-a43e-486f-9e2c-fb07917f2915"]})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.get = mock.Mock(return_value=get_return)
         instance = self.client.list()
         self.assertIsInstance(instance, list)
-        self.assertIn('dc5a4fd8-a43e-486f-9e2c-fb07917f2915',instance)
+        self.assertIn('dc5a4fd8-a43e-486f-9e2c-fb07917f2915', instance)
 
     def test_client_start(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata": {"state": "RUNNING",
+                                               "state_code": 3}})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.put = mock.Mock(return_value=get_return)
@@ -70,8 +91,9 @@ class LXDTestClient(test.TestCase):
         self.assertTrue(instance)
 
     def test_client_stop(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata": {"state": "RUNNING",
+                                               "state_code": 3}})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.put = mock.Mock(return_value=get_return)
@@ -79,8 +101,9 @@ class LXDTestClient(test.TestCase):
         self.assertTrue(instance)
 
     def test_client_reboot(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata": {"state": "RUNNING",
+                                               "state_code": 3}})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.put = mock.Mock(return_value=get_return)
@@ -88,8 +111,9 @@ class LXDTestClient(test.TestCase):
         self.assertTrue(instance)
 
     def test_client_pause(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata": {"state": "RUNNING",
+                                               "state_code": 3}})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.put = mock.Mock(return_value=get_return)
@@ -97,19 +121,11 @@ class LXDTestClient(test.TestCase):
         self.assertTrue(instance)
 
     def test_client_unpause(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
+        return_text = json.dumps({"type": "sync", "result": "success",
+                                  "metadata": {"state": "RUNNING",
+                                               "state_code": 3}})
         get_return = LXDFakeResponse(code=200,
                                      text=return_text)
         requests.put = mock.Mock(return_value=get_return)
         instance = self.client.unpause('test')
-        self.assertTrue(instance)
-
-    def test_client_reboot(self):
-        return_text = json.dumps({"type":"sync","result":"success",
-                                  "metadata":{"state":"RUNNING","state_code":3}})
-        get_return = LXDFakeResponse(code=200,
-                                     text=return_text)
-        requests.put = mock.Mock(return_value=get_return)
-        instance = self.client.reboot('test')
         self.assertTrue(instance)

--- a/nclxd/tests/test_driver.py
+++ b/nclxd/tests/test_driver.py
@@ -1,19 +1,31 @@
+# Copyright (c) 2015 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 import fixtures
-
-from oslo.config import cfg
 import mock
-
 from nova import test
-from nova.tests.unit import utils
 from nova.tests.unit.image import fake as fake_image
+from nova.tests.unit import utils
+from oslo.config import cfg
 
-
-from nclxd.nova.virt.lxd import driver
 from nclxd.nova.virt.lxd import client
 from nclxd.nova.virt.lxd import container
+from nclxd.nova.virt.lxd import driver
 
 CONF = cfg.CONF
 CONF.import_opt('image_cache_subdirectory_name', 'nova.virt.imagecache')
+
 
 class LXDTestDriver(test.TestCase):
     def setUp(self):
@@ -22,8 +34,9 @@ class LXDTestDriver(test.TestCase):
         self.ctxt = utils.get_test_admin_context()
         fake_image.stub_out_image_service(self.stubs)
 
-        self.flags(lxd_root_dir=self.useFixture(fixtures.TempDir()).path,
-                    group='lxd')
+        self.flags(lxd_root_dir=self.useFixture(
+                   fixtures.TempDir()).path,
+                   group='lxd')
         self.driver = driver.LXDDriver(None, None)
 
     @mock.patch.object(client.Client, 'list')
@@ -41,12 +54,13 @@ class LXDTestDriver(test.TestCase):
     @mock.patch.object(container.Container, '_fetch_image')
     @mock.patch.object(container.Container, '_start_container')
     def test_spawn_container(self, image_info=None, instance_href=None,
-                              network_info=None):
+                             network_info=None):
         instance_href = utils.get_test_instance()
         image_info = utils.get_test_image_info(None, instance_href)
         network_info = utils.get_test_network_info()
         self.driver.spawn(self.ctxt, instance_href, image_info,
-                          'fake_files', 'fake_password', network_info=network_info)
+                          'fake_files', 'fake_password',
+                          network_info=network_info)
 
     @mock.patch.object(container.Container, '_fetch_image')
     @mock.patch.object(container.Container, '_start_container')
@@ -57,19 +71,21 @@ class LXDTestDriver(test.TestCase):
         image_info = utils.get_test_image_info(None, instance_href)
         network_info = utils.get_test_network_info()
         self.driver.spawn(self.ctxt, instance_href, image_info,
-                          'fake_files', 'fake_password', network_info=network_info)
+                          'fake_files', 'fake_password',
+                          network_info=network_info)
         self.driver.destroy(self.ctxt, instance_href, network_info, None, True)
 
     @mock.patch.object(container.Container, '_fetch_image')
     @mock.patch.object(container.Container, '_start_container')
     @mock.patch.object(client.Client, 'reboot')
     def test_reboot_container(self, image_info=None, instance_href=None,
-                               network_info=None):
+                              network_info=None):
         reboot_type = "SOFT"
         instance_href = utils.get_test_instance()
         image_info = utils.get_test_image_info(None, instance_href)
         network_info = utils.get_test_network_info()
         self.driver.spawn(self.ctxt, instance_href, image_info,
-                          'fake_files', 'fake_password', network_info=network_info)
+                          'fake_files', 'fake_password',
+                          network_info=network_info)
         self.driver.reboot(self.ctxt, instance_href, network_info,
                            reboot_type)

--- a/nclxd/tests/test_vif.py
+++ b/nclxd/tests/test_vif.py
@@ -1,4 +1,19 @@
+# Copyright (c) 2015 Canonical Ltd
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 from nova import test
+
 
 class LXDTestNetwork(test.TestCase):
     def setUp(self):

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -180,7 +180,7 @@ function warn_on_flake8_without_venv {
 function run_pep8 {
   echo "Running flake8 ..."
   warn_on_flake8_without_venv
-  bash -c "${wrapper} flake8"
+  bash -c "${wrapper} flake8 --exclude tools/,.venv,doc"
 }
 
 


### PR DESCRIPTION
./run_tests.sh --pep8 cleanups, left the relative imports.  I couldn't complete the unit tests so it may have broken stuff; please check before merging.

Signed-off-by: Ryan Harper <ryan.harper@canonical.com>