### PR TITLE
Drop update for glance image metadata

### DIFF
--- a/nclxd/nova/virt/lxd/container_image.py
+++ b/nclxd/nova/virt/lxd/container_image.py
@@ -164,14 +164,3 @@ class LXDContainerImage(object):
             raise exception.ImageUnacceptable(
                 image_id=instance.image_ref,
                 reason=_('Image already exists: %s' % ex))
-
-        image_meta = {
-            'properties': {
-                'lxd-image-alias': instance.image_ref,
-                'lxd-manifest': self._get_lxd_manifest(image_meta)
-            }
-        }
-
-        IMAGE_API.update(context,
-                         instance.image_ref,
-                         image_meta)


### PR DESCRIPTION
nclxd should not be updating the metadata on a glance image; this
actually causes problems with image creation on subsequent
container creation events on different compute hosts, as the
presence of lxd-image-alias causes the image creation to not
happen.

Closes-Bug: 1499232