### PR TITLE
Use image-properties from glance to create manifest

### DIFF
--- a/nclxd/nova/virt/lxd/container_image.py
+++ b/nclxd/nova/virt/lxd/container_image.py
@@ -100,12 +100,12 @@ class LXDContainerImage(object):
             target_tarball = tarfile.open(container_manifest, "w:")
 
             metadata = {
-                'architecture': image_meta.get('hw_architecture',
+                'architecture': image_meta.properties.get('architecture',
                                                os.uname()[4]),
                 'creation_date': int(os.stat(container_manifest).st_ctime),
                 'properties': {
-                    'os': 'Unknown',
-                    'architecture': image_meta.get('hw_architecture',
+                    'os': image_meta.properties.get('os_distro', 'None'),
+                    'architecture': image_meta.get.properties('architecture',
                                                    os.uname()[4]),
                     'description': ' nclxd image %s' % instance.image_ref,
                     'name': instance.image_ref

--- a/nclxd/nova/virt/lxd/container_utils.py
+++ b/nclxd/nova/virt/lxd/container_utils.py
@@ -286,7 +286,7 @@ class LXDContainerDirectories(object):
 
     def get_container_manifest_image(self, image_meta):
         return os.path.join(self.base_dir,
-                            '%s-manifest.tar.gz' % image_meta.get('id'))
+                            '%s-manifest.tar' % image_meta.get('id'))
 
     def get_container_metadata(self, image_meta):
         return os.path.join(self.base_dir,
@@ -294,7 +294,7 @@ class LXDContainerDirectories(object):
 
     def get_container_rootfsImg(self, image_meta):
         return os.path.join(self.base_dir,
-                            '%s-root.tar.xz' % image_meta.get('id'))
+                            '%s-root.tar.gz' % image_meta.get('id'))
 
     def get_container_configdrive(self, instance):
         return os.path.join(CONF.instances_path,

--- a/nclxd/tests/test_container_image.py
+++ b/nclxd/tests/test_container_image.py
@@ -32,6 +32,7 @@ from nclxd.tests import stubs
 @mock.patch.object(container_image, 'CONF', stubs.MockConf())
 @mock.patch.object(container_utils, 'CONF', stubs.MockConf())
 class LXDTestContainerImage(test.NoDBTestCase):
+
     @mock.patch.object(container_utils, 'CONF', stubs.MockConf())
     def setUp(self):
         super(LXDTestContainerImage, self).setUp()
@@ -54,7 +55,7 @@ class LXDTestContainerImage(test.NoDBTestCase):
         image_meta = {'name': 'new_image', 'id': 'fake_image'}
         with contextlib.nested(
                 mock.patch.object(container_image.LXDContainerImage,
-                                 '_image_defined'),
+                                  '_image_defined'),
                 mock.patch.object(container_image.IMAGE_API,
                                   'download'),
                 mock.patch.object(container_image.LXDContainerImage,
@@ -76,9 +77,9 @@ class LXDTestContainerImage(test.NoDBTestCase):
             mock_image_manifest.return_value = \
                 '/fake/image/cache/fake_image-manifest.tar'
             self.assertEqual(None,
-                            self.container_image.setup_image(context,
-                                                             instance,
-                                                             image_meta))
+                             self.container_image.setup_image(context,
+                                                              instance,
+                                                              image_meta))
             mock_execute.assert_called_once_with('xz', '-9',
                                                  '/fake/image/cache/'
                                                  'fake_image-manifest.tar')
@@ -112,7 +113,7 @@ class LXDTestContainerImage(test.NoDBTestCase):
         ):
             mock_image_defined.return_value = True
             self.assertEqual(None,
-                self.container_image.setup_image(context,
-                                                instance,
-                                                image_meta))
+                             self.container_image.setup_image(context,
+                                                              instance,
+                                                              image_meta))
             self.assertFalse(mock_image_manifest.called)

--- a/nclxd/tests/test_container_image.py
+++ b/nclxd/tests/test_container_image.py
@@ -53,6 +53,8 @@ class LXDTestContainerImage(test.NoDBTestCase):
         instance = stubs._fake_instance()
         image_meta = {'name': 'new_image', 'id': 'fake_image'}
         with contextlib.nested(
+                mock.patch.object(container_image.LXDContainerImage,
+                                 '_image_defined'),
                 mock.patch.object(container_image.IMAGE_API,
                                   'download'),
                 mock.patch.object(container_image.LXDContainerImage,
@@ -63,18 +65,20 @@ class LXDTestContainerImage(test.NoDBTestCase):
                                   '_setup_alias'),
                 mock.patch.object(os, 'unlink')
         ) as (
+                mock_image_defined,
                 mock_image_download,
                 mock_image_manifest,
                 image_upload,
                 setup_alias,
                 os_unlink
         ):
+            mock_image_defined.return_value = expected_data
             mock_image_manifest.return_value = \
                 '/fake/image/cache/fake_image-manifest.tar'
             self.assertEqual(None,
-                             self.container_image.setup_image(context,
-                                                              instance,
-                                                              image_meta))
+                            self.container_image.setup_image(context,
+                                                             instance,
+                                                             image_meta))
             mock_execute.assert_called_once_with('xz', '-9',
                                                  '/fake/image/cache/'
                                                  'fake_image-manifest.tar')


### PR DESCRIPTION
Generate the lxd manifest from the image-properties from glance.