### PR TITLE
Ensure vifs are unplugged and destroyed appropriately

### DIFF
--- a/nclxd/nova/virt/lxd/container_ops.py
+++ b/nclxd/nova/virt/lxd/container_ops.py
@@ -166,8 +166,7 @@ class LXDContainerOperations(object):
         self._start_firewall(instance, network_info)
 
     def unplug_vifs(self, instance, network_info):
-        for viface in network_info:
-            self.vif_driver.plug(instance, viface)
+        self._unplug_vifs(instance, network_info, False)
         self._start_firewall(instance, network_info)
 
     def destroy(self, context, instance, network_info, block_device_info=None,
@@ -240,8 +239,20 @@ class LXDContainerOperations(object):
         self.container_utils.container_destroy(instance.uuid,
                                                instance.host)
 
+    def _unplug_vifs(self, instance, network_info, ignore_errors):
+        """Unplug VIFs from networks."""
+        for viface in network_info:
+            try:
+                self.vif_driver.unplug(instance, viface)
+            except exception.NovaException:
+                if not ignore_errors:
+                    raise
+
     def cleanup(self, context, instance, network_info, block_device_info=None,
                 destroy_disks=True, migrate_data=None, destroy_vifs=True):
+        if destroy_vifs:
+            self._unplug_vifs(instance, network_info, True)
+
         LOG.debug('container cleanup')
         container_dir = self.container_dir.get_instance_dir(instance.uuid)
         if os.path.exists(container_dir):

--- a/nclxd/tests/test_driver_api.py
+++ b/nclxd/tests/test_driver_api.py
@@ -204,14 +204,19 @@ class LXDTestDriver(test.NoDBTestCase):
         with contextlib.nested(
                 mock.patch.object(container_utils.LXDContainerUtils,
                                   'container_destroy'),
-                mock.patch.object(self.connection, 'cleanup')
+                mock.patch.object(self.connection, 'cleanup'),
+                mock.patch.object(container_ops.LXDContainerOperations,
+                                  '_unplug_vifs'),
         ) as (
                 container_destroy,
                 cleanup,
+                unplug_vifs
         ):
             self.connection.destroy(context, instance, network_info)
             self.assertTrue(container_destroy)
             self.assertTrue(cleanup)
+            unplug_vifs.assert_called_with(instance, network_info,
+                                           True)
 
     @mock.patch('os.path.exists', mock.Mock(return_value=True))
     @mock.patch('shutil.rmtree')


### PR DESCRIPTION
unplug vifs was incorrectly calling plug

also no cleanup for plugged vifs on destruction.