### PR TITLE
Handle container initialization failure

### DIFF
--- a/nclxd/nova/virt/lxd/container_ops.py
+++ b/nclxd/nova/virt/lxd/container_ops.py
@@ -99,7 +99,7 @@ class LXDContainerOperations(object):
                                   block_device_info, rescue, need_vif_plugged)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
-                LOG.exception(_LE('Upload image failed: %(e)s'),
+                LOG.exception(_LE('Container creation failed: %(e)s'),
                               {'e': ex})
         end = time.time()
         total = end - start

--- a/nclxd/tests/fake_api.py
+++ b/nclxd/tests/fake_api.py
@@ -247,6 +247,46 @@ def fake_operation():
     }
 
 
+def fake_operation_info_ok():
+    return {
+        "type": "async",
+        "status": "OK",
+        "status_code": 200,
+        "operation": "/1.0/operation/1234",
+        "metadata": {
+            "created_at": "2015-06-09T19:07:24.379615253-06:00",
+            "updated_at": "2015-06-09T19:07:23.379615253-06:00",
+            "status": "Completed",
+            "status_code": 200,
+            "resources": {
+                "containers": ["/1.0/containers/1"]
+            },
+            "metadata": {},
+            "may_cancel": True
+        }
+    }
+
+
+def fake_operation_info_failed():
+    return {
+        "type": "async",
+        "status": "OK",
+        "status_code": 200,
+        "operation": "/1.0/operation/1234",
+        "metadata": {
+            "created_at": "2015-06-09T19:07:24.379615253-06:00",
+            "updated_at": "2015-06-09T19:07:23.379615253-06:00",
+            "status": "Failure",
+            "status_code": 400,
+            "resources": {
+                "containers": ["/1.0/containers/1"]
+            },
+            "metadata": "Invalid container name",
+            "may_cancel": True
+        }
+    }
+
+
 def fake_network_list():
     return {
         "type": "sync",


### PR DESCRIPTION
operation_wait will always return success (as it indicates the success
of the wait, rather than the operation itself), so we need to query
the operation info when wait completes.

Raise an appropriate exception when container creation fails.