### PR TITLE
Transition to use instance.name

### DIFF
--- a/nclxd/nova/virt/lxd/container_migrate.py
+++ b/nclxd/nova/virt/lxd/container_migrate.py
@@ -53,9 +53,9 @@ class LXDContainerMigrate(object):
         LOG.debug("migrate_disk_and_power_off called", instance=instance)
 
         try:
-            self.utils.container_stop(instance.uuid, instance.host)
+            self.utils.container_stop(instance.name, instance.host)
 
-            container_ws = self.utils.container_migrate(instance.uuid,
+            container_ws = self.utils.container_migrate(instance.name,
                                                         instance)
             container_config = (
                 self.config.configure_container_migrate(
@@ -77,17 +77,17 @@ class LXDContainerMigrate(object):
         src_host = migration['source_compute']
         dst_host = migration['dest_compute']
         try:
-            if not self.client.client('defined', instance=instance.uuid,
+            if not self.client.client('defined', instance=instance.name,
                                       host=dst_host):
                 LOG.exception(_LE('Failed to migrate host'))
             LOG.info(_LI('Successfuly migrated instnace %(instance)s'),
-                     {'instance': instance.uuid}, instance=instance)
+                     {'instance': instance.name}, instance=instance)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.exception(_LE('Failed to confirm migration: %(e)s'),
                               {'e': ex}, instance=instance)
         finally:
-            self.utils.container_destroy(instance.uuid, src_host)
+            self.utils.container_destroy(instance.name, src_host)
 
     def finish_revert_migration(self, context, instance, network_info,
                                 block_device_info=None, power_on=True):
@@ -105,7 +105,7 @@ class LXDContainerMigrate(object):
                                                network_info,
                                                need_vif_plugged=True)
             LOG.info(_LI('Succesfuly migrated instnace %(instance)s '
-                         'on %(host)s'), {'instance': instance.uuid,
+                         'on %(host)s'), {'instance': instance.name,
                                           'host': migration['dest_compute']},
                      instance=instance)
         except Exception as ex:

--- a/nclxd/nova/virt/lxd/container_snapshot.py
+++ b/nclxd/nova/virt/lxd/container_snapshot.py
@@ -47,7 +47,7 @@ class LXDSnapshot(object):
 
         ''' Publish the image to LXD '''
         (state, data) = self.client.client('stop',
-                                           instance=instance.uuid,
+                                           instance=instance.name,
                                            host=instance.host)
         self.client.client('wait',
                            oid=data.get('operation').split('/')[3],
@@ -59,7 +59,7 @@ class LXDSnapshot(object):
         update_task_state(task_state=task_states.IMAGE_UPLOADING,
                           expected_state=task_states.IMAGE_PENDING_UPLOAD)
 
-        (state, data) = self.client.client('start', instance=instance.uuid,
+        (state, data) = self.client.client('start', instance=instance.name,
                                            host=instance.host)
 
     def create_container_snapshot(self, snapshot, instance):
@@ -67,7 +67,7 @@ class LXDSnapshot(object):
         csnapshot = {'name': snapshot['name'],
                      'stateful': False}
         (state, data) = self.client.client('snapshot_create',
-                                           instance=instance.uuid,
+                                           instance=instance.name,
                                            container_snapshot=csnapshot,
                                            host=instance.host)
         self.client.client('wait',
@@ -78,7 +78,7 @@ class LXDSnapshot(object):
         LOG.debug('Uploading image to LXD image store.')
         image = {
             'source': {
-                'name': '%s/%s' % (instance.uuid,
+                'name': '%s/%s' % (instance.name,
                                    snapshot['name']),
                 'type': 'snapshot'
             }

--- a/nclxd/nova/virt/lxd/container_utils.py
+++ b/nclxd/nova/virt/lxd/container_utils.py
@@ -77,18 +77,18 @@ class LXDContainerUtils(object):
         LOG.debug('Container reboot')
         try:
             (state, data) = self.client.client('reboot',
-                                               instance=instance.uuid,
+                                               instance=instance.name,
                                                host=instance.host)
             self.client.client('wait',
                                oid=data.get('operation').split('/')[3],
                                host=instance.host)
             LOG.info(_LI('Successfully rebooted container %s'),
-                     instance.uuid, instance=instance)
+                     instance.name, instance=instance)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.error(
                     _LE('Failed to reboot container %(instance)s: '
-                        '%(reason)s'), {'instance': instance.uuid,
+                        '%(reason)s'), {'instance': instance.name,
                                         'reason': ex}, instance=instance)
 
     def container_destroy(self, instance_name, host):
@@ -124,13 +124,13 @@ class LXDContainerUtils(object):
                                oid=data.get('operation').split('/')[3],
                                host=instance.host)
             LOG.info(_LI('Successfully paused container %s'),
-                     instance.uuid, instance=instance)
+                     instance.name, instance=instance)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.error(
                     _LE('Failed to pause container %(instance)s: '
                         '%(reason)s'),
-                    {'instance': instance.uuid,
+                    {'instance': instance.name,
                      'reason': ex}, instance=instance)
 
     def container_unpause(self, instance_name, instance):
@@ -143,7 +143,7 @@ class LXDContainerUtils(object):
                                oid=data.get('operation').split('/')[3],
                                host=instance.host)
             LOG.info(_LI('Successfully resumed container %s'),
-                     instance.uuid, instance=instance)
+                     instance_name, instance=instance)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.error(
@@ -154,19 +154,19 @@ class LXDContainerUtils(object):
     def container_snapshot(self, snapshot, instance):
         try:
             (state, data) = self.client.client('snapshot_create',
-                                               instance=instance.uuid,
+                                               instance=instance.name,
                                                container_snapshot=snapshot,
                                                host=instance.host)
             self.client.client('wait',
                                oid=data.get('operation').split('/')[3],
                                host=instance.host)
             LOG.info(_LI('Successfully snapshotted container %s'),
-                     instance.uuid, instance=instance)
+                     instance.name, instance=instance)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.error(
                     _LE('Failed to rename container %(instance)s: %(reason)s'),
-                    {'instance': instance.uuid,
+                    {'instance': instance.name,
                      'reason': ex}, instance=instance)
 
     def container_copy(self, config, instance):
@@ -179,12 +179,12 @@ class LXDContainerUtils(object):
                                oid=data.get('operation').split('/')[3],
                                host=instance.host)
             LOG.info(_LI('Successfully copied container %s'),
-                     instance.uuid, instance=instance)
+                     instance.name, instance=instance)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.error(
                     _LE('Failed to rename container %(instance): %(reason)s'),
-                    {'instance': instance.uuid,
+                    {'instance': instance.name,
                      'reason': ex})
 
     def container_move(self, old_name, config, instance):
@@ -198,12 +198,12 @@ class LXDContainerUtils(object):
                                oid=data.get('operation').split('/')[3],
                                host=instance.host)
             LOG.info(_LI('Successfully renamed container %s'),
-                     instance.uuid, instance=instance)
+                     instance.name, instance=instance)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.error(
                     _LE('Failed to rename container %(instance)s: %(reason)s'),
-                    {'instance': instance.uuid,
+                    {'instance': instance.name,
                      'reason': ex}, instance=instance)
 
     def container_migrate(self, instance_name, instance):
@@ -244,7 +244,7 @@ class LXDContainerUtils(object):
             with excutils.save_and_reraise_exception():
                 LOG.error(
                     _LE('Failed to create container %(instance)s: %(reason)s'),
-                    {'instance': instance.uuid,
+                    {'instance': instance.name,
                      'reason': ex}, instance=instance)
 
 

--- a/nclxd/nova/virt/lxd/driver.py
+++ b/nclxd/nova/virt/lxd/driver.py
@@ -83,7 +83,7 @@ class LXDDriver(driver.ComputeDriver):
 
     def instance_exists(self, instance):
         try:
-            return instance.uuid in self.list_instance_uuids()
+            return instance.name in self.list_instance_uuids()
         except NotImplementedError:
             return instance.name in self.list_instances()
 

--- a/nclxd/nova/virt/lxd/vif.py
+++ b/nclxd/nova/virt/lxd/vif.py
@@ -171,7 +171,7 @@ class LXDGenericDriver(object):
             utils.execute('brctl', 'addif', br_name, v1_name, run_as_root=True)
             linux_net.create_ovs_vif_port(self.get_bridge_name(vif),
                                           v2_name, iface_id,
-                                          vif['address'], instance.uuid)
+                                          vif['address'], instance.name)
 
     def unplug(self, instance, vif):
         vif_type = vif['type']

--- a/nclxd/tests/test_container_config.py
+++ b/nclxd/tests/test_container_config.py
@@ -45,9 +45,9 @@ class LXDTestContainerConfig(test.NoDBTestCase):
                         'limits.memory': '268435456',
                         'raw.lxc': 'lxc.console.logfile='
                                    '/fake/lxd/root/containers/'
-                                   'fake_uuid/console.log\n'},
+                                   'instance-00000001/console.log\n'},
              'devices': {},
-             'name': 'fake_uuid',
+             'name': 'instance-00000001',
              'profiles': ['fake_profile'],
              'source': {'alias': None, 'type': 'image'}},
             self.container_config.create_container(instance, [], {},
@@ -60,13 +60,14 @@ class LXDTestContainerConfig(test.NoDBTestCase):
             {'config': {'limits.cpus': '1',
                         'limits.memory': '268435456',
                         'raw.lxc': 'lxc.console.logfile='
-                                   '/fake/lxd/root/containers/fake_uuid/'
+                                   '/fake/lxd/root/containers'
+                                   '/instance-00000001/'
                                    'console.log\n'},
              'devices': {'rescue': {'path': 'mnt',
                                     'source': '/fake/lxd/root/containers/'
-                                    'fake_uuid-backup/rootfs',
+                                    'instance-00000001-backup/rootfs',
                                     'type': 'disk'}},
-             'name': 'fake_uuid',
+             'name': 'instance-00000001',
              'profiles': ['fake_profile'],
              'source': {'alias': None, 'type': 'image'}},
             self.container_config.create_container(instance, [], {},

--- a/nclxd/tests/test_container_migration.py
+++ b/nclxd/tests/test_container_migration.py
@@ -73,7 +73,7 @@ class LXDTestContainerMigrate(test.NoDBTestCase):
                              self.migrate.migrate_disk_and_power_off(
                 context, instance, dest, flavor, network_info))
             container_stop.assert_called_once_with(
-                instance.uuid, instance.host)
+                instance.name, instance.host)
 
     def test_confirm_migration(self):
         instance = stubs._fake_instance()
@@ -95,7 +95,7 @@ class LXDTestContainerMigrate(test.NoDBTestCase):
                              (self.migrate.confirm_migration(migration,
                                                              instance,
                                                              network_info)))
-            container_destroy.assert_called_once_with(instance.uuid,
+            container_destroy.assert_called_once_with(instance.name,
                                                       src)
 
     def test_finish_migration(self):


### PR DESCRIPTION
Due to commit bbf6380acc937bf4df302b3 instnace.uuid is no
longer a valid name for a container. Transition to
instance.name

Signed-off-by: Chuck Short <chuck.short@canonical.com>