### PR TITLE
Refactor network creation

### DIFF
--- a/nclxd/nova/virt/lxd/container_config.py
+++ b/nclxd/nova/virt/lxd/container_config.py
@@ -60,7 +60,8 @@ class LXDContainerConfig(object):
         return config
 
     def create_container(self, instance, injected_files,
-                         block_device_info, rescue):
+                         block_device_info, network_info,
+                         rescue):
         LOG.debug('Creating container config')
 
         # Ensure the directory exists and is writable
@@ -107,6 +108,13 @@ class LXDContainerConfig(object):
                     container_config,
                     instance))
             LOG.debug(pprint.pprint(container_rescue_devices))
+
+        if network_info:
+            for viface in network_info:
+                container_network_devices = (
+                    self.configure_network_devices(
+                        container_config, instance, viface))
+            LOG.debug(container_network_devices)
 
         return container_config
 

--- a/nclxd/nova/virt/lxd/container_ops.py
+++ b/nclxd/nova/virt/lxd/container_ops.py
@@ -112,17 +112,15 @@ class LXDContainerOperations(object):
                                             host=instance.host):
             container_config = (self.container_config.create_container(
                                 instance, injected_files, block_device_info,
-                                rescue))
+                                network_info, rescue))
 
             eventlet.spawn(self.container_utils.container_init,
                            container_config, instance,
                            instance.host).wait()
 
-            self.start_container(container_config, instance, network_info,
-                                 need_vif_plugged)
+            self.start_container(instance, network_info, need_vif_plugged)
 
-    def start_container(self, container_config, instance, network_info,
-                        need_vif_plugged):
+    def start_container(self, instance, network_info, need_vif_plugged):
         LOG.debug('Starting instance')
 
         if self.container_client.client('running', instance=instance.name,
@@ -143,9 +141,7 @@ class LXDContainerOperations(object):
             with self.virtapi.wait_for_instance_event(
                     instance, events, deadline=timeout,
                     error_callback=self._neutron_failed_callback):
-                self.plug_vifs(
-                    container_config, instance, network_info,
-                    need_vif_plugged)
+                self.plug_vifs(instance, network_info, need_vif_plugged)
         except exception.VirtualInterfaceCreateException:
             LOG.info(_LW('Failed to connect networking to instance'))
 
@@ -156,11 +152,8 @@ class LXDContainerOperations(object):
         LOG.debug('container reboot')
         return self.container_utils.container_reboot(instance)
 
-    def plug_vifs(self, container_config, instance, network_info,
-                  need_vif_plugged):
+    def plug_vifs(self, instance, network_info, need_vif_plugged):
         for viface in network_info:
-            container_config = self.container_config.configure_network_devices(
-                container_config, instance, viface)
             if need_vif_plugged:
                 self.vif_driver.plug(instance, viface)
         self._start_firewall(instance, network_info)

--- a/nclxd/tests/test_container_ops.py
+++ b/nclxd/tests/test_container_ops.py
@@ -163,8 +163,7 @@ class LXDTestContainerOps(test.NoDBTestCase):
                                'wait_for_instance_event') as mw:
             self.assertEqual(
                 None,
-                self.container_ops.start_container(container_config,
-                                                   instance,
+                self.container_ops.start_container(instance,
                                                    network_info,
                                                    need_vif_plugged))
             mw.assert_called_once_with(


### PR DESCRIPTION
Refactor network creation so that when the container config
is made include the network information.

Signed-off-by: Chuck Short <chuck.short@canonical.com>