### PR TITLE
Use snapshot id when creating images

### DIFF
--- a/nclxd/nova/virt/lxd/container_snapshot.py
+++ b/nclxd/nova/virt/lxd/container_snapshot.py
@@ -90,7 +90,7 @@ class LXDSnapshot(object):
 
         LOG.debug('Creating LXD alias')
         fingerprint = str(data['metadata']['fingerprint'])
-        snapshot_alias = {'name': snapshot['name'],
+        snapshot_alias = {'name': snapshot['id'],
                           'target': fingerprint}
         LOG.debug(snapshot_alias)
         self.client.client('alias_create',

--- a/nclxd/tests/test_driver_api.py
+++ b/nclxd/tests/test_driver_api.py
@@ -380,7 +380,7 @@ class LXDTestDriver(test.NoDBTestCase):
     )
     def test_snapshot_fail(self, tag, export_effect, update_effect, mi):
         instance = stubs.MockInstance()
-        mi.get.return_value = {'name': 'mock_snapshot'}
+        mi.get.return_value = {'id': 'abcdefgh', 'name': 'mock_snapshot'}
         self.ml.container_snapshot_create.return_value = (
             200, {'operation': '/1.0/operations/0123456789'})
         self.ml.container_stop.return_value = (
@@ -401,7 +401,7 @@ class LXDTestDriver(test.NoDBTestCase):
         instance = stubs.MockInstance()
         image_id = 'mock_image'
 
-        mi.get.return_value = {'name': 'mock_snapshot'}
+        mi.get.return_value = {'name': 'mock_snapshot', 'id': '123456789'}
         self.ml.container_snapshot_create.return_value = (
             200, {'operation': '/1.0/operations/0123456789'})
         self.ml.container_stop.return_value = (
@@ -435,7 +435,7 @@ class LXDTestDriver(test.NoDBTestCase):
                                                                 'snapshot',
                                                         'type': 'snapshot'}}),
             mock.call.lxd.alias_create(
-                {'name': 'mock_snapshot',
+                {'name': '123456789',
                  'target': 'abcdef0123456789'}),
             mock.call.lxd.image_export('abcdef0123456789'),
             mock.call.image.update(context,


### PR DESCRIPTION
Use the image_meta.id when creating a snapshot image,
otherwise container creation will fail with a bad image_ref.
This was caused by the fallout from instance.name -> instance.uuid.

Fixes issue #56

Signed-off-by: Chuck Short <chuck.short@canonical.com>