### PR TITLE
Fix container migration and resize

### DIFF
--- a/nclxd/nova/virt/lxd/container_utils.py
+++ b/nclxd/nova/virt/lxd/container_utils.py
@@ -209,18 +209,18 @@ class LXDContainerUtils(object):
                     {'instance': instance.name,
                      'reason': ex}, instance=instance)
 
-    def container_migrate(self, instance_name, instance):
+    def container_migrate(self, instance_name, host):
         LOG.debug('Migrate contianer')
         try:
             return self.client.client('migrate',
                                       instance=instance_name,
-                                      host=instance.host)
+                                      host=host)
         except Exception as ex:
             with excutils.save_and_reraise_exception():
                 LOG.error(
                     _LE('Failed to rename container %(instance): %(reason)s'),
                     {'instance': instance_name,
-                     'reason': ex}, instance=instance)
+                     'reason': ex})
 
     def container_init(self, config, instance, host):
         LOG.debug('Initializing container')

--- a/nclxd/nova/virt/lxd/driver.py
+++ b/nclxd/nova/virt/lxd/driver.py
@@ -42,9 +42,6 @@ lxd_opts = [
     cfg.StrOpt('default_profile',
                default='nclxd-profile',
                help='Default LXD profile'),
-    cfg.StrOpt('lxd_port',
-               default=8443,
-               help='Default LXD Port'),
     cfg.IntOpt('retry_interval',
                default=2,
                help='How often to retry in seconds when a'
@@ -63,7 +60,7 @@ class LXDDriver(driver.ComputeDriver):
     capabilities = {
         "has_imagecache": False,
         "supports_recreate": False,
-        "supports_migrate_to_same_host": True,
+        "supports_migrate_to_same_host": False,
     }
 
     def __init__(self, virtapi):

--- a/nclxd/tests/test_container_migration.py
+++ b/nclxd/tests/test_container_migration.py
@@ -21,9 +21,7 @@ from nova import test
 from nova.virt import fake
 
 from nclxd.nova.virt.lxd import container_client
-from nclxd.nova.virt.lxd import container_config
 from nclxd.nova.virt.lxd import container_migrate
-from nclxd.nova.virt.lxd import container_ops
 from nclxd.nova.virt.lxd import container_utils
 from nclxd.tests import stubs
 
@@ -46,15 +44,15 @@ class LXDTestContainerMigrate(test.NoDBTestCase):
         bdevice_info = mock.Mock()
         disk_info = mock.Mock()
         network_info = mock.Mock()
-        with contextlib.nested( 
+        with contextlib.nested(
             mock.patch.object(container_client.LXDContainerClient,
                               'client'),
             mock.patch.object(container_utils.LXDContainerUtils,
-                             'container_stop'),
+                              'container_stop'),
             mock.patch.object(container_utils.LXDContainerUtils,
-                             'container_init'),
+                              'container_init'),
             mock.patch.object(container_utils.LXDContainerUtils,
-                             'container_destroy'),
+                              'container_destroy'),
         ) as (
             container_defined,
             container_stop,
@@ -62,9 +60,9 @@ class LXDTestContainerMigrate(test.NoDBTestCase):
             container_destroy
         ):
             self.assertEqual(None,
-                            (self.migrate.finish_migration(context,
-                            migration,
-                            instance,
-                            disk_info,
-                            network_info,
-                            bdevice_info)))
+                             (self.migrate.finish_migration(context,
+                                                            migration,
+                                                            instance,
+                                                            disk_info,
+                                                            network_info,
+                                                            bdevice_info)))

--- a/nclxd/tests/test_container_migration.py
+++ b/nclxd/tests/test_container_migration.py
@@ -18,7 +18,6 @@ import contextlib
 import mock
 
 from nova import test
-from nova import utils
 from nova.virt import fake
 
 from nclxd.nova.virt.lxd import container_client
@@ -39,65 +38,6 @@ class LXDTestContainerMigrate(test.NoDBTestCase):
         self.migrate = container_migrate.LXDContainerMigrate(
             fake.FakeVirtAPI())
 
-    def test_migrate_disk_and_power_off(self):
-        instance = stubs._fake_instance()
-        context = mock.Mock()
-        dest = mock.Mock()
-        flavor = mock.Mock()
-        network_info = mock.Mock()
-        container_config = mock.Mock()
-        with contextlib.nested(
-            mock.patch.object(container_utils.LXDContainerUtils,
-                              'container_stop'),
-            mock.patch.object(container_utils.LXDContainerUtils,
-                              'container_migrate'),
-            mock.patch.object(container_config.LXDContainerConfig,
-                              'get_container_config'),
-            mock.patch.object(container_client.LXDContainerClient,
-                              'container_config'),
-            mock.patch.object(container_config.LXDContainerConfig,
-                              'configure_container_migrate'),
-            mock.patch.object(container_utils.LXDContainerUtils,
-                              'container_init'),
-            mock.patch.object(utils, 'spawn')
-        ) as (
-            container_stop,
-            container_migrate,
-            container_migrate_config,
-            get_container_config,
-            container_config,
-            container_init,
-            spawn
-        ):
-            self.assertEqual({},
-                             self.migrate.migrate_disk_and_power_off(
-                context, instance, dest, flavor, network_info))
-            container_stop.assert_called_once_with(
-                instance.name, instance.host)
-
-    def test_confirm_migration(self):
-        instance = stubs._fake_instance()
-        migration = mock.Mock()
-        network_info = mock.Mock()
-        migration = {'source_compute': 'fake-source',
-                     'dest_compute': 'fake-dest'}
-        src = migration['source_compute']
-        with contextlib.nested(
-            mock.patch.object(container_client.LXDContainerClient,
-                              'client'),
-            mock.patch.object(container_utils.LXDContainerUtils,
-                              'container_destroy')
-        ) as (
-            container_defined,
-            container_destroy
-        ):
-            self.assertEqual(None,
-                             (self.migrate.confirm_migration(migration,
-                                                             instance,
-                                                             network_info)))
-            container_destroy.assert_called_once_with(instance.name,
-                                                      src)
-
     def test_finish_migration(self):
         context = mock.Mock()
         migration = {'source_compute': 'fake-source',
@@ -106,22 +46,25 @@ class LXDTestContainerMigrate(test.NoDBTestCase):
         bdevice_info = mock.Mock()
         disk_info = mock.Mock()
         network_info = mock.Mock()
-        with contextlib.nested(
-            mock.patch.object(container_config.LXDContainerConfig,
-                              'get_container_config'),
+        with contextlib.nested( 
             mock.patch.object(container_client.LXDContainerClient,
                               'client'),
-            mock.patch.object(container_ops.LXDContainerOperations,
-                              'start_container')
+            mock.patch.object(container_utils.LXDContainerUtils,
+                             'container_stop'),
+            mock.patch.object(container_utils.LXDContainerUtils,
+                             'container_init'),
+            mock.patch.object(container_utils.LXDContainerUtils,
+                             'container_destroy'),
         ) as (
-            get_container_config,
-            container_mock_client,
-            container_start
+            container_defined,
+            container_stop,
+            container_init,
+            container_destroy
         ):
             self.assertEqual(None,
-                             (self.migrate.finish_migration(context,
-                                                            migration,
-                                                            instance,
-                                                            disk_info,
-                                                            network_info,
-                                                            bdevice_info)))
+                            (self.migrate.finish_migration(context,
+                            migration,
+                            instance,
+                            disk_info,
+                            network_info,
+                            bdevice_info)))

--- a/nclxd/tests/test_driver_api.py
+++ b/nclxd/tests/test_driver_api.py
@@ -73,7 +73,7 @@ class LXDTestDriver(test.NoDBTestCase):
     def test_capabilities(self):
         self.assertFalse(self.connection.capabilities['has_imagecache'])
         self.assertFalse(self.connection.capabilities['supports_recreate'])
-        self.assertTrue(
+        self.assertFalse(
             self.connection.capabilities['supports_migrate_to_same_host'])
 
     def test_init_host(self):


### PR DESCRIPTION
Fix contianer migration and resize, there is no need to resize
a container "disk" right now since flavor.disk is not supported.
Also do the migration last before everything is ready.

Signed-off-by: Chuck Short <chuck.short@canonical.com>